### PR TITLE
Simplify host/port configuration with environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,20 @@ OR
 # STDIO transport (default)
 uv run python server.py
 
-# SSE transport on port 8000
+# SSE transport (uses HOST=0.0.0.0, PORT=8000 by default)
 uv run python server.py --sse
 
-# SSE transport on custom port
-uv run python server.py --sse 9000
-
-# HTTP transport on port 8000
+# HTTP transport (uses HOST=0.0.0.0, PORT=8000 by default)
 uv run python server.py --http
+
+# Custom host and port via environment variables
+HOST=localhost PORT=9000 uv run python server.py --sse
+HOST=192.168.1.100 PORT=8080 uv run python server.py --http
+
+# Set environment variables persistently
+export HOST=localhost
+export PORT=9000
+uv run python server.py --sse
 ```
 
 ### FastMCP CLI Integration
@@ -136,9 +142,10 @@ The server supports multiple transport methods:
 - **HTTP**: Standard HTTP for API access
 
 ```bash
-uv run python server.py          # STDIO (default)
-uv run python server.py --sse    # SSE on port 8000
-uv run python server.py --http   # HTTP on port 8000
+uv run python server.py                        # STDIO (default)
+uv run python server.py --sse                  # SSE (HOST=0.0.0.0, PORT=8000)
+uv run python server.py --http                 # HTTP (HOST=0.0.0.0, PORT=8000)
+HOST=localhost PORT=9000 uv run python server.py --sse   # Custom host/port
 ```
 
 ## Development

--- a/server.py
+++ b/server.py
@@ -341,25 +341,24 @@ def main():
         # Support multiple transport methods
         import sys
 
+        # Get host and port from environment variables
+        host = os.getenv("HOST", "0.0.0.0")
+        port = int(os.getenv("PORT", "8000"))
+
         # Check for transport argument
         transport = "stdio"  # default
-        port = 8000
-
-        if len(sys.argv) > 1:
-            if sys.argv[1] == "--sse":
-                transport = "sse"
-                if len(sys.argv) > 2:
-                    port = int(sys.argv[2])
-            elif sys.argv[1] == "--http":
-                transport = "streamable-http"
-                if len(sys.argv) > 2:
-                    port = int(sys.argv[2])
+        if "--sse" in sys.argv:
+            transport = "sse"
+        elif "--http" in sys.argv:
+            transport = "streamable-http"
+        elif "--stdio" in sys.argv:
+            transport = "stdio"
 
         logger.info(f"Starting Metabase MCP server with {transport} transport")
 
         if transport in ["sse", "streamable-http"]:
-            logger.info(f"Server will be available at http://localhost:{port}")
-            mcp.run(transport=transport, port=port)
+            logger.info(f"Server will be available at http://{host}:{port}")
+            mcp.run(transport=transport, host=host, port=port)
         else:
             mcp.run(transport=transport)
 


### PR DESCRIPTION
Hi. Ran into an issue with configuring the HOST of the fastmcp server. This PR removes the port from the flags (since it relied on a positional argument) and creates both `PORT` and `HOST` as environment variables.

- Replace complex positional arguments with simple transport flags
- Add HOST and PORT environment variables (defaults: 0.0.0.0:8000)
- Support only --sse, --http, --stdio flags for transport selection
- Update README with environment variable usage examples

Please let me know if a different direction is needed.