### PR TITLE
Add new tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ fastmcp install server.py -n "Metabase MCP"
 | `list_cards` | List all saved questions/cards |
 | `create_card` | Create new questions/cards with SQL queries |
 | `create_mongodb_card` | Create new MongoDB questions/cards with native query support |
+| `update_card_display` | Update the display type and visualization settings of a card |
+| `set_card_goal_line` | Set a goal line on a card's visualization with a value and optional label |
 
 ### Dashboard Management
 | Tool | Description |
@@ -231,8 +233,8 @@ fastmcp install server.py -n "Metabase MCP"
 | `list_dashboards` | List all dashboards with metadata |
 | `get_dashboard_cards` | Get cards and layout for a specific dashboard |
 | `add_card_to_dashboard` | Add an existing card to a dashboard at a specified position |
-| `copy_dashboard` | Copy a dashboard including all cards, tabs, and filters. Defaults to shallow copy (shared cards); set `is_deep_copy=true` for independent duplicate cards |
-| `copy_dashboard_tab` | Copy a tab within a dashboard, preserving card layouts, parameter mappings, and visualization settings. Defaults to shallow copy; set `is_deep_copy=true` for independent duplicate cards |
+| `copy_dashboard` | Copy a dashboard including all cards, tabs, and filters. Defaults to deep copy (independent duplicate cards); set `is_deep_copy=false` for a shallow copy that shares the original cards |
+| `copy_dashboard_tab` | Copy a tab to the same or a different dashboard, preserving card layouts, parameter mappings, and visualization settings. Defaults to deep copy (independent duplicate cards); set `is_deep_copy=false` for a shallow copy |
 
 ### Collection Management
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ fastmcp install server.py -n "Metabase MCP"
 | `list_dashboards` | List all dashboards with metadata |
 | `get_dashboard_cards` | Get cards and layout for a specific dashboard |
 | `add_card_to_dashboard` | Add an existing card to a dashboard at a specified position |
-| `copy_dashboard` | Copy a dashboard including all cards, tabs, and filters. Supports deep copy (independent duplicate cards) or shallow copy (shared cards) via `is_deep_copy` |
-| `copy_dashboard_tab` | Copy a tab into a dashboard, preserving card layouts, parameter mappings, and visualization settings. Optionally specify a destination dashboard |
+| `copy_dashboard` | Copy a dashboard including all cards, tabs, and filters. Defaults to shallow copy (shared cards); set `is_deep_copy=true` for independent duplicate cards |
+| `copy_dashboard_tab` | Copy a tab within a dashboard, preserving card layouts, parameter mappings, and visualization settings. Defaults to shallow copy; set `is_deep_copy=true` for independent duplicate cards |
 
 ### Collection Management
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ fastmcp install server.py -n "Metabase MCP"
 | Tool | Description |
 |------|------------|
 | `list_dashboards` | List all dashboards with metadata |
+| `rename_dashboard` | Rename a dashboard |
+| `set_dashboard_filter` | Set the default value of a filter on a dashboard, identified by name or slug |
 | `get_dashboard_cards` | Get cards and layout for a specific dashboard |
 | `add_card_to_dashboard` | Add an existing card to a dashboard at a specified position |
 | `copy_dashboard` | Copy a dashboard including all cards, tabs, and filters. Defaults to deep copy (independent duplicate cards); set `is_deep_copy=false` for a shallow copy that shares the original cards |

--- a/README.md
+++ b/README.md
@@ -225,6 +225,15 @@ fastmcp install server.py -n "Metabase MCP"
 | `create_card` | Create new questions/cards with SQL queries |
 | `create_mongodb_card` | Create new MongoDB questions/cards with native query support |
 
+### Dashboard Management
+| Tool | Description |
+|------|------------|
+| `list_dashboards` | List all dashboards with metadata |
+| `get_dashboard_cards` | Get cards and layout for a specific dashboard |
+| `add_card_to_dashboard` | Add an existing card to a dashboard at a specified position |
+| `copy_dashboard` | Copy a dashboard including all cards, tabs, and filters. Supports deep copy (independent duplicate cards) or shallow copy (shared cards) via `is_deep_copy` |
+| `copy_dashboard_tab` | Copy a tab into a dashboard, preserving card layouts, parameter mappings, and visualization settings. Optionally specify a destination dashboard |
+
 ### Collection Management
 | Tool | Description |
 |------|------------|

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ fastmcp install server.py -n "Metabase MCP"
 | `list_dashboards` | List all dashboards with metadata |
 | `rename_dashboard` | Rename a dashboard |
 | `set_dashboard_filter` | Set the default value of a filter on a dashboard, identified by name or slug |
+| `pin_dashboard` | Pin a dashboard to its collection at the next available pin position |
 | `get_dashboard_cards` | Get cards and layout for a specific dashboard |
 | `add_card_to_dashboard` | Add an existing card to a dashboard at a specified position |
 | `copy_dashboard` | Copy a dashboard including all cards, tabs, and filters. Defaults to deep copy (independent duplicate cards); set `is_deep_copy=false` for a shallow copy that shares the original cards |

--- a/server.py
+++ b/server.py
@@ -680,6 +680,55 @@ async def set_dashboard_filter(
 
 
 @mcp.tool
+async def pin_dashboard(
+    dashboard_id: int,
+    ctx: Context,
+) -> dict[str, Any]:
+    """
+    Pin a dashboard to its collection.
+
+    Fetches the dashboard to determine its collection, then queries that
+    collection to find the highest current pin position and pins the dashboard
+    one position after it.
+
+    Args:
+        dashboard_id: The ID of the dashboard to pin.
+
+    Returns:
+        The updated dashboard object.
+    """
+    try:
+        await ctx.info(f"Pinning dashboard {dashboard_id}")
+
+        dashboard = await metabase_client.request("GET", f"/dashboard/{dashboard_id}")
+        collection_id = dashboard.get("collection_id")
+
+        # Find the highest existing pin position in the collection
+        collection_key = str(collection_id) if collection_id is not None else "root"
+        items = await metabase_client.request("GET", f"/collection/{collection_key}/items")
+        pinned = [
+            item.get("collection_position")
+            for item in items.get("data", [])
+            if item.get("collection_position") is not None
+        ]
+        next_position = max(pinned, default=0) + 1
+
+        result = await metabase_client.request(
+            "PUT", f"/dashboard/{dashboard_id}",
+            json={"collection_position": next_position},
+        )
+        await ctx.info(
+            f"Successfully pinned dashboard {dashboard_id} at position {next_position} "
+            f"in collection {collection_key}"
+        )
+        return result
+    except Exception as e:
+        error_msg = f"Error pinning dashboard {dashboard_id}: {e}"
+        await ctx.error(error_msg)
+        raise ToolError(error_msg) from e
+
+
+@mcp.tool
 async def rename_dashboard(
     dashboard_id: int,
     new_name: str,

--- a/server.py
+++ b/server.py
@@ -718,13 +718,13 @@ async def copy_dashboard_tab(
     dashboard_id: int,
     tab_id: int,
     ctx: Context,
-    destination_dashboard_id: int | None = None,
+    target_dashboard_id: int | None = None,
     is_deep_copy: bool = True,
 ) -> dict[str, Any]:
     """
     Copy a tab from one dashboard to another (or within the same dashboard).
 
-    Supports cross-dashboard tab copying: pass destination_dashboard_id to place
+    Supports cross-dashboard tab copying: pass target_dashboard_id to place
     the new tab on a different dashboard. If omitted, the tab is copied within
     the same dashboard.
 
@@ -739,7 +739,7 @@ async def copy_dashboard_tab(
     Args:
         dashboard_id: The ID of the dashboard containing the source tab.
         tab_id: The ID of the tab to copy.
-        destination_dashboard_id: ID of the dashboard to place the new tab in.
+        target_dashboard_id: ID of the dashboard to place the new tab in.
                                   If omitted, the tab is copied within dashboard_id.
                                   Use this to copy a tab to a different dashboard.
         is_deep_copy: Default True (deep copy — cards are duplicated and fully
@@ -750,7 +750,7 @@ async def copy_dashboard_tab(
         The updated destination dashboard object containing the new tab.
     """
     try:
-        dest_id = destination_dashboard_id if destination_dashboard_id is not None else dashboard_id
+        dest_id = target_dashboard_id if target_dashboard_id is not None else dashboard_id
         copy_type = "deep" if is_deep_copy else "shallow"
         await ctx.info(
             f"Creating {copy_type} copy of tab {tab_id} from dashboard {dashboard_id} "

--- a/server.py
+++ b/server.py
@@ -584,6 +584,44 @@ async def update_card_display(
         raise ToolError(error_msg) from e
 
 
+@mcp.tool
+async def set_card_goal_line(
+    card_id: int,
+    value: float,
+    ctx: Context,
+    label: str = "Goal",
+) -> dict[str, Any]:
+    """
+    Set a goal line on a card's visualization.
+
+    Args:
+        card_id: The ID of the card to update.
+        value: The numeric value at which to draw the goal line.
+        label: Label for the goal line (default: "Goal").
+
+    Returns:
+        The updated card object.
+    """
+    try:
+        await ctx.info(f"Setting goal line on card {card_id} to {value} ('{label}')")
+
+        card = await metabase_client.request("GET", f"/card/{card_id}")
+        viz = dict(card.get("visualization_settings") or {})
+        viz["graph.show_goal"] = True
+        viz["graph.goal_value"] = value
+        viz["graph.goal_label"] = label
+
+        result = await metabase_client.request(
+            "PUT", f"/card/{card_id}", json={"visualization_settings": viz}
+        )
+        await ctx.info(f"Successfully set goal line on card {card_id}")
+        return result
+    except Exception as e:
+        error_msg = f"Error setting goal line on card {card_id}: {e}"
+        await ctx.error(error_msg)
+        raise ToolError(error_msg) from e
+
+
 # =============================================================================
 # Tool Definitions - Dashboard Operations
 # =============================================================================

--- a/server.py
+++ b/server.py
@@ -627,6 +627,88 @@ async def set_card_goal_line(
 # =============================================================================
 
 @mcp.tool
+async def set_dashboard_filter(
+    dashboard_id: int,
+    filter: str,
+    value: Any,
+    ctx: Context,
+) -> dict[str, Any]:
+    """
+    Set the default value of a filter on a dashboard.
+
+    Identifies the filter by matching against its name or slug (case-insensitive).
+
+    Args:
+        dashboard_id: The ID of the dashboard.
+        filter: The name or slug of the filter to update.
+        value: The default value to set for the filter.
+
+    Returns:
+        The updated dashboard object.
+    """
+    try:
+        await ctx.info(f"Setting filter '{filter}' to '{value}' on dashboard {dashboard_id}")
+
+        dashboard = await metabase_client.request("GET", f"/dashboard/{dashboard_id}")
+        parameters = dashboard.get("parameters", [])
+
+        filter_lower = filter.lower()
+        matched = next(
+            (p for p in parameters
+             if p.get("name", "").lower() == filter_lower
+             or p.get("slug", "").lower() == filter_lower),
+            None,
+        )
+        if not matched:
+            raise ValueError(
+                f"No filter named '{filter}' found on dashboard {dashboard_id}. "
+                f"Available filters: {[p.get('name') for p in parameters]}"
+            )
+
+        matched["default"] = value
+        result = await metabase_client.request(
+            "PUT", f"/dashboard/{dashboard_id}", json={"parameters": parameters}
+        )
+        await ctx.info(
+            f"Successfully set filter '{filter}' default to '{value}' on dashboard {dashboard_id}"
+        )
+        return result
+    except Exception as e:
+        error_msg = f"Error setting filter on dashboard {dashboard_id}: {e}"
+        await ctx.error(error_msg)
+        raise ToolError(error_msg) from e
+
+
+@mcp.tool
+async def rename_dashboard(
+    dashboard_id: int,
+    new_name: str,
+    ctx: Context,
+) -> dict[str, Any]:
+    """
+    Rename a dashboard.
+
+    Args:
+        dashboard_id: The ID of the dashboard to rename.
+        new_name: The new name for the dashboard.
+
+    Returns:
+        The updated dashboard object.
+    """
+    try:
+        await ctx.info(f"Renaming dashboard {dashboard_id} to '{new_name}'")
+        result = await metabase_client.request(
+            "PUT", f"/dashboard/{dashboard_id}", json={"name": new_name}
+        )
+        await ctx.info(f"Successfully renamed dashboard {dashboard_id} to '{new_name}'")
+        return result
+    except Exception as e:
+        error_msg = f"Error renaming dashboard {dashboard_id}: {e}"
+        await ctx.error(error_msg)
+        raise ToolError(error_msg) from e
+
+
+@mcp.tool
 async def list_dashboards(ctx: Context) -> list[dict[str, Any]]:
     """
     List all dashboards in Metabase.

--- a/server.py
+++ b/server.py
@@ -660,24 +660,24 @@ async def copy_dashboard(
     dashboard_id: int,
     ctx: Context,
     collection_id: int | None = None,
-    is_deep_copy: bool = True,
+    is_deep_copy: bool = False,
 ) -> dict[str, Any]:
     """
     Create a copy of a dashboard, including all cards, tabs, and filters.
 
     The new dashboard is named "{original name} - Copy".
 
-    When is_deep_copy is True (default), all cards are duplicated so the new
-    dashboard is fully independent. When False, the copy shares the original
-    cards — changes to those questions will affect both dashboards.
+    When is_deep_copy is False (default), the copy shares the original cards —
+    changes to those questions will affect both dashboards. When True, all cards
+    are duplicated so the new dashboard is fully independent.
 
     Args:
         dashboard_id: The ID of the dashboard to copy.
         collection_id: Optional collection ID for the new dashboard. Defaults to
                        the same collection as the original.
-        is_deep_copy: When True (default), duplicate all cards so the new
-                      dashboard is independent. When False, share the original
-                      cards between both dashboards.
+        is_deep_copy: When False (default), share the original cards between
+                      both dashboards. When True, duplicate all cards so the
+                      new dashboard is independent.
 
     Returns:
         The newly created dashboard object.
@@ -716,7 +716,7 @@ async def copy_dashboard_tab(
     dashboard_id: int,
     tab_id: int,
     ctx: Context,
-    is_deep_copy: bool = True,
+    is_deep_copy: bool = False,
 ) -> dict[str, Any]:
     """
     Copy a tab within a dashboard, duplicating all its cards and layout.
@@ -726,17 +726,17 @@ async def copy_dashboard_tab(
     and visualization settings are preserved.
 
     Note: Metabase has no API for deep-copying cards at the tab level. When
-    is_deep_copy is False, the new tab's cards reference the same original
-    questions (shallow). When True (default), the entire dashboard is first
+    is_deep_copy is False (default), the new tab's cards reference the same
+    original questions (shallow). When True, the entire dashboard is first
     deep-copied and then the corresponding tab is moved back — ensuring the
     new tab's cards are independent duplicates.
 
     Args:
         dashboard_id: The ID of the dashboard containing the tab.
         tab_id: The ID of the tab to copy.
-        is_deep_copy: When True (default), cards on the new tab are independent
-                      duplicates. When False, the new tab shares the original
-                      questions with the source tab.
+        is_deep_copy: When False (default), the new tab shares the original
+                      questions with the source tab. When True, cards on the
+                      new tab are independent duplicates.
 
     Returns:
         The updated dashboard object containing the new tab.

--- a/server.py
+++ b/server.py
@@ -656,6 +656,223 @@ async def get_dashboard_cards(dashboard_id: int, ctx: Context) -> list[dict[str,
 
 
 @mcp.tool
+async def copy_dashboard(
+    dashboard_id: int,
+    ctx: Context,
+    collection_id: int | None = None,
+    is_deep_copy: bool = True,
+) -> dict[str, Any]:
+    """
+    Create a copy of a dashboard, including all cards, tabs, and filters.
+
+    The new dashboard is named "{original name} - Copy".
+
+    When is_deep_copy is True (default), all cards are duplicated so the new
+    dashboard is fully independent. When False, the copy shares the original
+    cards — changes to those questions will affect both dashboards.
+
+    Args:
+        dashboard_id: The ID of the dashboard to copy.
+        collection_id: Optional collection ID for the new dashboard. Defaults to
+                       the same collection as the original.
+        is_deep_copy: When True (default), duplicate all cards so the new
+                      dashboard is independent. When False, share the original
+                      cards between both dashboards.
+
+    Returns:
+        The newly created dashboard object.
+    """
+    try:
+        copy_type = "deep" if is_deep_copy else "shallow"
+        await ctx.info(f"Creating {copy_type} copy of dashboard {dashboard_id}")
+
+        original = await metabase_client.request("GET", f"/dashboard/{dashboard_id}")
+        original_name = original.get("name", "Dashboard")
+        target_collection_id = collection_id if collection_id is not None else original.get("collection_id")
+
+        payload: dict[str, Any] = {
+            "name": f"{original_name} - Copy",
+            "is_deep_copy": is_deep_copy,
+        }
+        if target_collection_id is not None:
+            payload["collection_id"] = target_collection_id
+
+        result = await metabase_client.request(
+            "POST", f"/dashboard/{dashboard_id}/copy", json=payload
+        )
+        await ctx.info(
+            f"Successfully created {copy_type} copy of dashboard {dashboard_id} "
+            f"→ new dashboard {result.get('id')}"
+        )
+        return result
+    except Exception as e:
+        error_msg = f"Error copying dashboard {dashboard_id}: {e}"
+        await ctx.error(error_msg)
+        raise ToolError(error_msg) from e
+
+
+@mcp.tool
+async def copy_dashboard_tab(
+    dashboard_id: int,
+    tab_id: int,
+    ctx: Context,
+    is_deep_copy: bool = True,
+) -> dict[str, Any]:
+    """
+    Copy a tab within a dashboard, duplicating all its cards and layout.
+
+    The new tab is named "{original tab name} - Copy" and appended to the end
+    of the dashboard's tab list. All card positions, sizes, parameter mappings,
+    and visualization settings are preserved.
+
+    Note: Metabase has no API for deep-copying cards at the tab level. When
+    is_deep_copy is False, the new tab's cards reference the same original
+    questions (shallow). When True (default), the entire dashboard is first
+    deep-copied and then the corresponding tab is moved back — ensuring the
+    new tab's cards are independent duplicates.
+
+    Args:
+        dashboard_id: The ID of the dashboard containing the tab.
+        tab_id: The ID of the tab to copy.
+        is_deep_copy: When True (default), cards on the new tab are independent
+                      duplicates. When False, the new tab shares the original
+                      questions with the source tab.
+
+    Returns:
+        The updated dashboard object containing the new tab.
+    """
+    try:
+        copy_type = "deep" if is_deep_copy else "shallow"
+        await ctx.info(f"Creating {copy_type} copy of tab {tab_id} in dashboard {dashboard_id}")
+
+        dashboard = await metabase_client.request("GET", f"/dashboard/{dashboard_id}")
+        tabs = dashboard.get("tabs", [])
+        dashcards = dashboard.get("dashcards", dashboard.get("ordered_cards", []))
+
+        source_tab = next((t for t in tabs if t.get("id") == tab_id), None)
+        if not source_tab:
+            raise ValueError(f"Tab {tab_id} not found in dashboard {dashboard_id}")
+
+        source_tab_name = source_tab.get("name", "Tab")
+        new_tab_name = f"{source_tab_name} - Copy"
+
+        # Step 1: add the new tab (no new dashcards yet)
+        existing_dashcards_payload = [
+            {
+                "id": dc["id"],
+                "card_id": dc.get("card_id"),
+                "row": dc.get("row"),
+                "col": dc.get("col"),
+                "size_x": dc.get("size_x"),
+                "size_y": dc.get("size_y"),
+                "dashboard_tab_id": dc.get("dashboard_tab_id"),
+                "parameter_mappings": dc.get("parameter_mappings", []),
+                "visualization_settings": dc.get("visualization_settings", {}),
+            }
+            for dc in dashcards
+        ]
+        tabs_payload = [{"id": t["id"], "name": t["name"]} for t in tabs]
+        tabs_payload.append({"id": -1, "name": new_tab_name})
+
+        step1 = await metabase_client.request(
+            "PUT", f"/dashboard/{dashboard_id}",
+            json={"tabs": tabs_payload, "dashcards": existing_dashcards_payload},
+        )
+
+        # Resolve the real ID of the new tab
+        new_tab = next(
+            (t for t in step1.get("tabs", []) if t.get("name") == new_tab_name), None
+        )
+        if not new_tab:
+            raise Exception("New tab was not returned by Metabase after creation")
+        new_tab_id = new_tab["id"]
+        await ctx.debug(f"Created new tab with ID {new_tab_id}")
+
+        # Step 2: determine the card_ids to place on the new tab
+        step1_dashcards = step1.get("dashcards", step1.get("ordered_cards", []))
+        source_dashcards = [dc for dc in step1_dashcards if dc.get("dashboard_tab_id") == tab_id]
+
+        if is_deep_copy:
+            # There is no API to deep-copy cards at the tab level, so we deep-copy
+            # the entire dashboard as a temporary copy, pull the duplicated card IDs
+            # from the corresponding tab, then delete the temp dashboard.
+            await ctx.debug("Deep-copying entire dashboard to obtain duplicated card IDs")
+            source_tab_index = next(
+                (i for i, t in enumerate(tabs) if t.get("id") == tab_id), None
+            )
+            temp_copy = await metabase_client.request(
+                "POST", f"/dashboard/{dashboard_id}/copy",
+                json={"name": "__temp_tab_copy__", "is_deep_copy": True},
+            )
+            temp_id = temp_copy["id"]
+            try:
+                temp_dashboard = await metabase_client.request("GET", f"/dashboard/{temp_id}")
+                temp_tabs = temp_dashboard.get("tabs", [])
+                temp_dashcards = temp_dashboard.get(
+                    "dashcards", temp_dashboard.get("ordered_cards", [])
+                )
+                if source_tab_index is None or source_tab_index >= len(temp_tabs):
+                    raise Exception("Could not find corresponding tab in deep-copied dashboard")
+                temp_tab_id = temp_tabs[source_tab_index]["id"]
+                card_sources = [
+                    dc for dc in temp_dashcards if dc.get("dashboard_tab_id") == temp_tab_id
+                ]
+                # Pair each source dashcard with its duplicated card_id by position
+                new_dashcards = [
+                    {
+                        "id": -(i + 1),
+                        "card_id": card_sources[i].get("card_id") if i < len(card_sources) else dc.get("card_id"),
+                        "row": dc.get("row"),
+                        "col": dc.get("col"),
+                        "size_x": dc.get("size_x"),
+                        "size_y": dc.get("size_y"),
+                        "dashboard_tab_id": new_tab_id,
+                        "parameter_mappings": dc.get("parameter_mappings", []),
+                        "visualization_settings": dc.get("visualization_settings", {}),
+                    }
+                    for i, dc in enumerate(source_dashcards)
+                ]
+            finally:
+                await metabase_client.request("DELETE", f"/dashboard/{temp_id}")
+                await ctx.debug(f"Deleted temporary dashboard {temp_id}")
+        else:
+            # Shallow copy: new tab references the same original card IDs
+            new_dashcards = [
+                {
+                    "id": -(i + 1),
+                    "card_id": dc.get("card_id"),
+                    "row": dc.get("row"),
+                    "col": dc.get("col"),
+                    "size_x": dc.get("size_x"),
+                    "size_y": dc.get("size_y"),
+                    "dashboard_tab_id": new_tab_id,
+                    "parameter_mappings": dc.get("parameter_mappings", []),
+                    "visualization_settings": dc.get("visualization_settings", {}),
+                }
+                for i, dc in enumerate(source_dashcards)
+            ]
+
+        all_dashcards = existing_dashcards_payload + new_dashcards
+        step1_tabs = [{"id": t["id"], "name": t["name"]} for t in step1.get("tabs", [])]
+
+        result = await metabase_client.request(
+            "PUT", f"/dashboard/{dashboard_id}",
+            json={"tabs": step1_tabs, "dashcards": all_dashcards},
+        )
+
+        copy_type = "deep" if is_deep_copy else "shallow"
+        await ctx.info(
+            f"Successfully created {copy_type} copy of tab {tab_id} → new tab {new_tab_id} "
+            f"with {len(new_dashcards)} cards in dashboard {dashboard_id}"
+        )
+        return result
+    except Exception as e:
+        error_msg = f"Error copying tab {tab_id} in dashboard {dashboard_id}: {e}"
+        await ctx.error(error_msg)
+        raise ToolError(error_msg) from e
+
+
+@mcp.tool
 async def add_card_to_dashboard(
     dashboard_id: int,
     card_id: int,

--- a/server.py
+++ b/server.py
@@ -123,7 +123,10 @@ class MetabaseClient:
         response = await self.client.request(method=method, url=url, headers=headers, **kwargs)
 
         if not response.is_success:
-            error_data = response.json() if response.content else {}
+            try:
+                error_data = response.json() if response.content else {}
+            except Exception:
+                error_data = {}
             error_message = (
                 f"API request failed with status {response.status_code}: {response.text}"
             )
@@ -660,24 +663,26 @@ async def copy_dashboard(
     dashboard_id: int,
     ctx: Context,
     collection_id: int | None = None,
-    is_deep_copy: bool = False,
+    is_deep_copy: bool = True,
 ) -> dict[str, Any]:
     """
     Create a copy of a dashboard, including all cards, tabs, and filters.
 
     The new dashboard is named "{original name} - Copy".
 
-    When is_deep_copy is False (default), the copy shares the original cards —
-    changes to those questions will affect both dashboards. When True, all cards
-    are duplicated so the new dashboard is fully independent.
+    By default performs a deep copy — all cards are duplicated so the new
+    dashboard is fully independent of the original. Pass is_deep_copy=False
+    only when the user explicitly requests a shallow copy; in that case the
+    new dashboard shares the original cards and changes to those questions
+    will affect both dashboards.
 
     Args:
         dashboard_id: The ID of the dashboard to copy.
         collection_id: Optional collection ID for the new dashboard. Defaults to
                        the same collection as the original.
-        is_deep_copy: When False (default), share the original cards between
-                      both dashboards. When True, duplicate all cards so the
-                      new dashboard is independent.
+        is_deep_copy: Default True (deep copy — cards are duplicated and fully
+                      independent). Set False only when the user explicitly
+                      requests a shallow/shared copy.
 
     Returns:
         The newly created dashboard object.
@@ -690,10 +695,7 @@ async def copy_dashboard(
         original_name = original.get("name", "Dashboard")
         target_collection_id = collection_id if collection_id is not None else original.get("collection_id")
 
-        payload: dict[str, Any] = {
-            "name": f"{original_name} - Copy",
-            "is_deep_copy": is_deep_copy,
-        }
+        payload: dict[str, Any] = {"name": f"{original_name} - Copy", "is_deep_copy": is_deep_copy}
         if target_collection_id is not None:
             payload["collection_id"] = target_collection_id
 
@@ -716,47 +718,66 @@ async def copy_dashboard_tab(
     dashboard_id: int,
     tab_id: int,
     ctx: Context,
-    is_deep_copy: bool = False,
+    destination_dashboard_id: int | None = None,
+    is_deep_copy: bool = True,
 ) -> dict[str, Any]:
     """
-    Copy a tab within a dashboard, duplicating all its cards and layout.
+    Copy a tab from one dashboard to another (or within the same dashboard).
+
+    Supports cross-dashboard tab copying: pass destination_dashboard_id to place
+    the new tab on a different dashboard. If omitted, the tab is copied within
+    the same dashboard.
 
     The new tab is named "{original tab name} - Copy" and appended to the end
-    of the dashboard's tab list. All card positions, sizes, parameter mappings,
-    and visualization settings are preserved.
+    of the destination dashboard's tab list. All card positions, sizes,
+    parameter mappings, and visualization settings are preserved.
 
-    Note: Metabase has no API for deep-copying cards at the tab level. When
-    is_deep_copy is False (default), the new tab's cards reference the same
-    original questions (shallow). When True, the entire dashboard is first
-    deep-copied and then the corresponding tab is moved back — ensuring the
-    new tab's cards are independent duplicates.
+    By default performs a deep copy — all cards are duplicated so the new tab
+    is fully independent. Pass is_deep_copy=False only when the user explicitly
+    requests a shallow copy; in that case the new tab shares the original cards.
 
     Args:
-        dashboard_id: The ID of the dashboard containing the tab.
+        dashboard_id: The ID of the dashboard containing the source tab.
         tab_id: The ID of the tab to copy.
-        is_deep_copy: When False (default), the new tab shares the original
-                      questions with the source tab. When True, cards on the
-                      new tab are independent duplicates.
+        destination_dashboard_id: ID of the dashboard to place the new tab in.
+                                  If omitted, the tab is copied within dashboard_id.
+                                  Use this to copy a tab to a different dashboard.
+        is_deep_copy: Default True (deep copy — cards are duplicated and fully
+                      independent). Set False only when the user explicitly
+                      requests a shallow/shared copy.
 
     Returns:
-        The updated dashboard object containing the new tab.
+        The updated destination dashboard object containing the new tab.
     """
     try:
+        dest_id = destination_dashboard_id if destination_dashboard_id is not None else dashboard_id
         copy_type = "deep" if is_deep_copy else "shallow"
-        await ctx.info(f"Creating {copy_type} copy of tab {tab_id} in dashboard {dashboard_id}")
+        await ctx.info(
+            f"Creating {copy_type} copy of tab {tab_id} from dashboard {dashboard_id} "
+            f"to dashboard {dest_id}"
+        )
 
-        dashboard = await metabase_client.request("GET", f"/dashboard/{dashboard_id}")
-        tabs = dashboard.get("tabs", [])
-        dashcards = dashboard.get("dashcards", dashboard.get("ordered_cards", []))
+        # Fetch source dashboard to locate the tab and its cards
+        source_dashboard = await metabase_client.request("GET", f"/dashboard/{dashboard_id}")
+        source_tabs = source_dashboard.get("tabs", [])
+        source_dashcards = source_dashboard.get("dashcards", source_dashboard.get("ordered_cards", []))
 
-        source_tab = next((t for t in tabs if t.get("id") == tab_id), None)
+        source_tab = next((t for t in source_tabs if t.get("id") == tab_id), None)
         if not source_tab:
             raise ValueError(f"Tab {tab_id} not found in dashboard {dashboard_id}")
 
-        source_tab_name = source_tab.get("name", "Tab")
-        new_tab_name = f"{source_tab_name} - Copy"
+        new_tab_name = f"{source_tab.get('name', 'Tab')} - Copy"
+        tab_dashcards = [dc for dc in source_dashcards if dc.get("dashboard_tab_id") == tab_id]
 
-        # Step 1: add the new tab (no new dashcards yet)
+        # Fetch destination dashboard (may be the same as source)
+        if dest_id == dashboard_id:
+            dest_dashboard = source_dashboard
+        else:
+            dest_dashboard = await metabase_client.request("GET", f"/dashboard/{dest_id}")
+
+        dest_tabs = dest_dashboard.get("tabs", [])
+        dest_dashcards = dest_dashboard.get("dashcards", dest_dashboard.get("ordered_cards", []))
+
         existing_dashcards_payload = [
             {
                 "id": dc["id"],
@@ -769,74 +790,51 @@ async def copy_dashboard_tab(
                 "parameter_mappings": dc.get("parameter_mappings", []),
                 "visualization_settings": dc.get("visualization_settings", {}),
             }
-            for dc in dashcards
+            for dc in dest_dashcards
         ]
-        tabs_payload = [{"id": t["id"], "name": t["name"]} for t in tabs]
+
+        # Step 1: add the new tab to the destination dashboard
+        tabs_payload = [{"id": t["id"], "name": t["name"]} for t in dest_tabs]
         tabs_payload.append({"id": -1, "name": new_tab_name})
 
         step1 = await metabase_client.request(
-            "PUT", f"/dashboard/{dashboard_id}",
+            "PUT", f"/dashboard/{dest_id}",
             json={"tabs": tabs_payload, "dashcards": existing_dashcards_payload},
         )
 
-        # Resolve the real ID of the new tab
-        new_tab = next(
-            (t for t in step1.get("tabs", []) if t.get("name") == new_tab_name), None
-        )
+        new_tab = next((t for t in step1.get("tabs", []) if t.get("name") == new_tab_name), None)
         if not new_tab:
             raise Exception("New tab was not returned by Metabase after creation")
         new_tab_id = new_tab["id"]
         await ctx.debug(f"Created new tab with ID {new_tab_id}")
 
-        # Step 2: determine the card_ids to place on the new tab
-        step1_dashcards = step1.get("dashcards", step1.get("ordered_cards", []))
-        source_dashcards = [dc for dc in step1_dashcards if dc.get("dashboard_tab_id") == tab_id]
-
+        # Step 2: build the new dashcards for the copied tab
         if is_deep_copy:
-            # There is no API to deep-copy cards at the tab level, so we deep-copy
-            # the entire dashboard as a temporary copy, pull the duplicated card IDs
-            # from the corresponding tab, then delete the temp dashboard.
-            await ctx.debug("Deep-copying entire dashboard to obtain duplicated card IDs")
-            source_tab_index = next(
-                (i for i, t in enumerate(tabs) if t.get("id") == tab_id), None
-            )
-            temp_copy = await metabase_client.request(
-                "POST", f"/dashboard/{dashboard_id}/copy",
-                json={"name": "__temp_tab_copy__", "is_deep_copy": True},
-            )
-            temp_id = temp_copy["id"]
-            try:
-                temp_dashboard = await metabase_client.request("GET", f"/dashboard/{temp_id}")
-                temp_tabs = temp_dashboard.get("tabs", [])
-                temp_dashcards = temp_dashboard.get(
-                    "dashcards", temp_dashboard.get("ordered_cards", [])
-                )
-                if source_tab_index is None or source_tab_index >= len(temp_tabs):
-                    raise Exception("Could not find corresponding tab in deep-copied dashboard")
-                temp_tab_id = temp_tabs[source_tab_index]["id"]
-                card_sources = [
-                    dc for dc in temp_dashcards if dc.get("dashboard_tab_id") == temp_tab_id
-                ]
-                # Pair each source dashcard with its duplicated card_id by position
-                new_dashcards = [
-                    {
-                        "id": -(i + 1),
-                        "card_id": card_sources[i].get("card_id") if i < len(card_sources) else dc.get("card_id"),
-                        "row": dc.get("row"),
-                        "col": dc.get("col"),
-                        "size_x": dc.get("size_x"),
-                        "size_y": dc.get("size_y"),
-                        "dashboard_tab_id": new_tab_id,
-                        "parameter_mappings": dc.get("parameter_mappings", []),
-                        "visualization_settings": dc.get("visualization_settings", {}),
-                    }
-                    for i, dc in enumerate(source_dashcards)
-                ]
-            finally:
-                await metabase_client.request("DELETE", f"/dashboard/{temp_id}")
-                await ctx.debug(f"Deleted temporary dashboard {temp_id}")
+            # Copy each card individually via POST /api/card/:id/copy so the new tab
+            # gets independent duplicates without touching the rest of the dashboard.
+            await ctx.debug(f"Copying {len(tab_dashcards)} cards individually")
+            new_dashcards = []
+            for i, dc in enumerate(tab_dashcards):
+                card_id = dc.get("card_id")
+                if card_id is not None:
+                    new_card = await metabase_client.request("POST", f"/card/{card_id}/copy")
+                    new_card_id = new_card.get("id")
+                    await ctx.debug(f"Copied card {card_id} → {new_card_id}")
+                else:
+                    new_card_id = None
+                new_dashcards.append({
+                    "id": -(i + 1),
+                    "card_id": new_card_id,
+                    "row": dc.get("row"),
+                    "col": dc.get("col"),
+                    "size_x": dc.get("size_x"),
+                    "size_y": dc.get("size_y"),
+                    "dashboard_tab_id": new_tab_id,
+                    "parameter_mappings": dc.get("parameter_mappings", []),
+                    "visualization_settings": dc.get("visualization_settings", {}),
+                })
         else:
-            # Shallow copy: new tab references the same original card IDs
+            # Shallow copy: new tab shares the original card IDs
             new_dashcards = [
                 {
                     "id": -(i + 1),
@@ -849,25 +847,24 @@ async def copy_dashboard_tab(
                     "parameter_mappings": dc.get("parameter_mappings", []),
                     "visualization_settings": dc.get("visualization_settings", {}),
                 }
-                for i, dc in enumerate(source_dashcards)
+                for i, dc in enumerate(tab_dashcards)
             ]
 
         all_dashcards = existing_dashcards_payload + new_dashcards
         step1_tabs = [{"id": t["id"], "name": t["name"]} for t in step1.get("tabs", [])]
 
         result = await metabase_client.request(
-            "PUT", f"/dashboard/{dashboard_id}",
+            "PUT", f"/dashboard/{dest_id}",
             json={"tabs": step1_tabs, "dashcards": all_dashcards},
         )
 
-        copy_type = "deep" if is_deep_copy else "shallow"
         await ctx.info(
             f"Successfully created {copy_type} copy of tab {tab_id} → new tab {new_tab_id} "
-            f"with {len(new_dashcards)} cards in dashboard {dashboard_id}"
+            f"with {len(new_dashcards)} cards in dashboard {dest_id}"
         )
         return result
     except Exception as e:
-        error_msg = f"Error copying tab {tab_id} in dashboard {dashboard_id}: {e}"
+        error_msg = f"Error copying tab {tab_id} from dashboard {dashboard_id}: {e}"
         await ctx.error(error_msg)
         raise ToolError(error_msg) from e
 


### PR DESCRIPTION
# Purpose
The intention of this PR is to add some tools to the Metabase MCP, which can be used with Claude to automate some dashboard operations.

## Tools:
- copy_dashboard: Create deep or shallow copies of dashboards to the same or other collections.
- copy_dashboard_tab: Create a copy of a tab in the same or a target dashboard. 
- rename_dashboard: Rename a dashboard.
- set_dashboard_filter: Set a filter on a dashboard.
- set_card_goal_line: Set goal lines.
- pin_dashboard: Pin the dashboard to collection